### PR TITLE
Refactor monthly cumulative average transaction fee

### DIFF
--- a/hiive/models/marts/dim_hiive_employee_users.sql
+++ b/hiive/models/marts/dim_hiive_employee_users.sql
@@ -8,5 +8,4 @@ SELECT
 FROM
    {{ ref('stg_users') }}
 WHERE
-   email LIKE '%@hiive.com'
-   OR email LIKE '%@hiivemarkets.com'
+   is_hiive_employee = TRUE

--- a/hiive/models/marts/monthly_cumulative_average_transaction_fee.sql
+++ b/hiive/models/marts/monthly_cumulative_average_transaction_fee.sql
@@ -4,38 +4,63 @@
 
 WITH
 
+transactions as (
+    SELECT
+        id,
+        inserted_at_pst,
+        fee,
+        seller_id
+    FROM {{ ref('stg_transactions') }}
+),
+
+transaction_transitions AS (
+    SELECT
+        transaction_id,
+        transitioned_at_pst
+    FROM {{ ref('stg_transaction_transitions') }}
+    WHERE new_state = 'closed_fee_pending'
+),
+
+users as (
+    SELECT
+        id,
+        investor_type,
+        is_hiive_employee
+    FROM {{ ref('stg_users') }}
+),
+
+
+monthly_average_fee AS (
+    SELECT
+        DATE_TRUNC(
+            'month',
+            COALESCE(transaction_transitions.transitioned_at_pst, transactions.inserted_at_pst)
+        ) AS transaction_month,
+        AVG(transactions.fee) AS avg_monthly_fee
+    
+    FROM transactions
+        LEFT JOIN transaction_transitions -- do we want INNER JOIN? if yes, transaction_month can be simplified
+            ON transactions.id = transaction_transitions.transaction_id
+        LEFT JOIN users
+            ON transactions.seller_id = users.id
+    WHERE
+        users.investor_type = 'unaccredited_seller'
+        AND users.is_hiive_employee = FALSE
+
+    GROUP BY transaction_month
+),
+
 monthly_avg_fee AS (
     SELECT
-        transaction_date,
-        AVG(monthly_fee) OVER (
-            ORDER BY transaction_date
+        transaction_month,
+        AVG(avg_monthly_fee) OVER (
+            ORDER BY transaction_month
             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-        ) AS cumulative_average_fee
-    FROM (
-        SELECT
-            DATE_TRUNC(
-                'month',
-                COALESCE(transaction_transitions.transitioned_at_pst, transactions.inserted_at_pst)
-            ) AS transaction_date,
-            AVG(fee) AS monthly_fee
-          FROM {{ ref('stg_transactions') }} AS transactions
-            LEFT JOIN {{ ref('stg_transaction_transitions') }} AS transaction_transitions
-                ON transactions.id = transaction_transitions.transaction_id
-                AND transaction_transitions.new_state = 'closed_fee_pending'
-            LEFT JOIN {{ ref('stg_users') }} AS users
-                ON transactions.seller_id = users.id
-        WHERE
-            transaction_transitions.new_state = 'closed_fee_pending'
-            AND users.investor_type = 'unaccredited_seller'
-            AND seller_id NOT IN (
-                SELECT id 
-                FROM {{ref('dim_hiive_employee_users')}}
-            )
-        GROUP BY transaction_date
-    ) AS monthly_fee_data
+        ) AS cumulative_monthly_average_fee
+    FROM monthly_average_fee
 )
 
-
-SELECT 
-*
+SELECT
+    transaction_month,
+    cumulative_monthly_average_fee
 FROM monthly_avg_fee

--- a/hiive/models/marts/monthly_cumulative_average_transaction_fee.sql
+++ b/hiive/models/marts/monthly_cumulative_average_transaction_fee.sql
@@ -50,7 +50,7 @@ monthly_average_fee AS (
     GROUP BY transaction_month
 ),
 
-monthly_avg_fee AS (
+monthly_cumulative_fee AS (
     SELECT
         transaction_month,
         AVG(avg_monthly_fee) OVER (
@@ -63,4 +63,4 @@ monthly_avg_fee AS (
 SELECT
     transaction_month,
     cumulative_monthly_average_fee
-FROM monthly_avg_fee
+FROM monthly_cumulative_fee

--- a/hiive/models/staging/stg_users.sql
+++ b/hiive/models/staging/stg_users.sql
@@ -13,5 +13,10 @@ with users as (
 select
     id,
     email,
-    investor_type
+    investor_type,
+    case 
+        when email LIKE '%@hiive.com' or email LIKE '%@hiivemarkets.com'
+            then TRUE
+        else FALSE
+    end as is_hiive_employee
 from users


### PR DESCRIPTION
Changes:
- added `is_hiive_employee` flag to `stg_users` model, 
- it made `dim_hiive_employee_users` more trivial
- split `monthly_cumulative_average_transaction_fee` into multiple CTEs
    - there three "import" CTEs: `transactions`, `transaction_transitions` and `users`
    - corresponding calculation and filters were pushed to those import CTEs
    - `monthly_average_fee` now only includes monthly averages, some conditions from the original query were simplified
    - cumulative fee metric now lives in a separate CTE
    - final SELECT now all contains all columns instead of `*`